### PR TITLE
Improved performance of @UniqueElements(by=NOT_SET)`

### DIFF
--- a/engine/src/main/java/net/jqwik/engine/properties/FeatureExtractor.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/FeatureExtractor.java
@@ -29,7 +29,12 @@ public interface FeatureExtractor<T> extends Function<T, Object> {
 	}
 
 	default boolean areUnique(Collection<T> elements) {
-		long uniqueCount = elements.stream().map(this::applySafe).distinct().count();
-		return uniqueCount == elements.size();
+		Set<Object> set = new HashSet<>();
+		for (T x : elements) {
+			if (!set.add(applySafe(x))) {
+				return false;
+			}
+		}
+		return true;
 	}
 }

--- a/engine/src/test/java/net/jqwik/api/constraints/UniqueElementsProperties.java
+++ b/engine/src/test/java/net/jqwik/api/constraints/UniqueElementsProperties.java
@@ -55,11 +55,29 @@ class UniqueElementsProperties {
 	@Group
 	class Sets {
 		@Property
+		boolean sets(@ForAll @UniqueElements Set<String> aStringSet) {
+			// May seem unnecessary but catches:
+			//   * ClassCastException or NullPointerException
+			//   * Empty Arbitrary
+			return hasNoDuplicates(aStringSet, s -> s);
+		}
+
+		@Property
 		boolean setsWithByClause(
 				@ForAll @UniqueElements(by = GetFirstTwoChars.class)
 						Set<@StringLength(3) @AlphaChars String> aStringSet
 		) {
 			return hasNoDuplicates(aStringSet, new GetFirstTwoChars());
+		}
+
+		@Property
+		boolean setsNotFromSetArbitrary(
+			@ForAll("setsOfStrings") @UniqueElements Set<String> aStringSet
+		) {
+			// May seem unnecessary but catches:
+			//   * ClassCastException or NullPointerException
+			//   * Empty Arbitrary
+			return hasNoDuplicates(aStringSet, s -> s);
 		}
 
 		@Property


### PR DESCRIPTION
## Overview

This PR aims at significantly improving the performance of `@UniqueElements(by=NOT_SET)`, mainly by replacing calls to `uniqueElements(x->x)` by `uniqueElements()` wherever possible.

### Details

If we look at the following two property tests:

```java
@PropertyDefaults( tries = 100_000 )
public class UniqueElementsTest
{
  @Property void testA( @ForAll @UniqueElements int[] a ) {
    Arrays.sort(a);
    for( int i=1; i < a.length; i++ )
      assert a[i-1] <= a[i];
  }

  @Provide Arbitrary<int[]> arrays() {
    return Arbitraries.integers().array(int[].class).uniqueElements();
  }

  @Property void testB( @ForAll("arrays") int[] a ) {
    Arrays.sort(a);
    for( int i=1; i < a.length; i++ )
      assert a[i-1] <= a[i];
  }
}
```

On my machine, it takes 20 seconds for `testA` to finish while `testB` only takes 2 seconds. The problem becomes much more emphasized with larger array sizes.

---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jqwik-team/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
