### PR TITLE
Kotlin190

### DIFF
--- a/api/src/main/java/net/jqwik/api/Builders.java
+++ b/api/src/main/java/net/jqwik/api/Builders.java
@@ -53,7 +53,7 @@ public class Builders {
 		 * @param <T>
 		 * @return new {@linkplain CombinableBuilder} instance
 		 */
-		public <T> CombinableBuilder<B, T> use(Arbitrary<T> arbitrary) {
+		public <T> CombinableBuilder<B, @Nullable T> use(Arbitrary<@Nullable T> arbitrary) {
 			return new CombinableBuilder<>(this, 1.0, arbitrary);
 		}
 
@@ -201,7 +201,7 @@ public class Builders {
 		 * @return new {@linkplain BuilderCombinator} instance
 		 */
 		@SuppressWarnings("unchecked")
-		public BuilderCombinator<B> in(BiFunction<B, T, B> toFunction) {
+		public BuilderCombinator<B> in(BiFunction<B, @Nullable T, B> toFunction) {
 			if (probabilityOfUse == 0.0) {
 				return combinator;
 			}

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
 }
 
 plugins {
-	id 'org.jetbrains.kotlin.jvm' version "1.8.22" apply false
+	id 'org.jetbrains.kotlin.jvm' version "1.9.0" apply false
 	id 'org.jetbrains.dokka' version "1.8.20" apply false
 	id 'org.beryx.jar' version "2.0.0" apply false
 }

--- a/kotlin/src/main/kotlin/net/jqwik/kotlin/api/ArbitraryExtensions.kt
+++ b/kotlin/src/main/kotlin/net/jqwik/kotlin/api/ArbitraryExtensions.kt
@@ -3,7 +3,6 @@ package net.jqwik.kotlin.api
 import net.jqwik.api.Arbitrary
 import net.jqwik.api.arbitraries.ArrayArbitrary
 import org.apiguardian.api.API
-import kotlin.reflect.KClass
 
 /**
  * Create a new arbitrary of the same type but inject null values with a probability of `nullProbability`.
@@ -58,6 +57,7 @@ fun <T> Arbitrary<T>.triple(): Arbitrary<Triple<T, T, T>> {
  * @return a new arbitrary instance
  */
 @API(status = API.Status.EXPERIMENTAL, since = "1.6.0")
-inline fun <T, reified A> Arbitrary<T>.array(): ArrayArbitrary<T, A> {
-    return array(A::class.java)
+inline fun <T, reified A> Arbitrary<T>.array(): ArrayArbitrary<T, A>
+    where A : Any {
+    return array(A::class.java) as ArrayArbitrary<T, A>
 }

--- a/kotlin/src/main/kotlin/net/jqwik/kotlin/api/ArbitraryExtensions.kt
+++ b/kotlin/src/main/kotlin/net/jqwik/kotlin/api/ArbitraryExtensions.kt
@@ -24,7 +24,7 @@ fun <T> Arbitrary<T>.orNull(nullProbability: Double): Arbitrary<T?> {
  * @return a new arbitrary instance
  */
 @API(status = API.Status.EXPERIMENTAL, since = "1.6.0")
-fun <T> Arbitrary<T>.sequence(): SequenceArbitrary<T> {
+fun <T> Arbitrary<T>.sequence(): SequenceArbitrary<T> where T: Any {
     return SequenceArbitrary(this)
 }
 

--- a/kotlin/src/main/kotlin/net/jqwik/kotlin/api/BuildersExtensions.kt
+++ b/kotlin/src/main/kotlin/net/jqwik/kotlin/api/BuildersExtensions.kt
@@ -1,6 +1,7 @@
 package net.jqwik.kotlin.api
 
 import net.jqwik.api.Arbitrary
+import net.jqwik.api.Builders
 import net.jqwik.api.Builders.BuilderCombinator
 import org.apiguardian.api.API
 import java.util.function.BiFunction
@@ -9,9 +10,9 @@ import java.util.function.BiFunction
  * Convenience function for Kotlin to not use backticked `in` function.
  */
 @API(status = API.Status.EXPERIMENTAL, since = "1.6.0")
-fun <B, T> BuilderCombinator<B>.use(arbitrary: Arbitrary<T>, combinator: (B, T) -> B): BuilderCombinator<B> {
+fun <B, T> BuilderCombinator<B & Any>.use(arbitrary: Arbitrary<T>, combinator: (B, T) -> B): BuilderCombinator<B> {
     // This explicit conversion form combinator to toFunction is necessary
     // since the implicit conversion (just handing in combinator) creates nullability warning
-    val toFunction: BiFunction<B, T, B> = BiFunction<B, T, B> { b, t -> combinator(b, t) }
-    return this.use(arbitrary).`in`(toFunction)
+    val toFunction: BiFunction<B & Any, T?, B & Any> = BiFunction<B & Any, T?, B & Any> { b, t -> combinator(b, t) }
+    return this.use(arbitrary as Arbitrary<T?>).`in`(toFunction) as BuilderCombinator<B>
 }

--- a/kotlin/src/main/kotlin/net/jqwik/kotlin/api/CollectionExtensions.kt
+++ b/kotlin/src/main/kotlin/net/jqwik/kotlin/api/CollectionExtensions.kt
@@ -9,10 +9,10 @@ import org.apiguardian.api.API
  * Convenience function to replace Arbitraries.subsetOf(..)
  */
 @API(status = API.Status.EXPERIMENTAL, since = "1.6.5")
-fun <T> Collection<T>.anySubset(): SetArbitrary<T> = Arbitraries.subsetOf(this)
+fun <T> Collection<T & Any>.anySubset(): SetArbitrary<T & Any> = Arbitraries.subsetOf(this)
 
 /**
  * Convenience function to replace Arbitraries.of(..)
  */
 @API(status = API.Status.EXPERIMENTAL, since = "1.7.1")
-fun <T> Collection<T>.anyValue(): Arbitrary<T> = Arbitraries.of(this)
+fun <T> Collection<T & Any>.anyValue(): Arbitrary<T & Any> = Arbitraries.of(this)

--- a/kotlin/src/main/kotlin/net/jqwik/kotlin/api/JqwikGlobals.kt
+++ b/kotlin/src/main/kotlin/net/jqwik/kotlin/api/JqwikGlobals.kt
@@ -96,7 +96,8 @@ fun <T> runBlockingProperty(
  * This is a Kotlin convenience for [Arbitraries.forType] which requires a Java class instead.
  */
 @API(status = API.Status.EXPERIMENTAL, since = "1.6.0")
-inline fun <reified T> anyForType(): TypeArbitrary<T> {
+inline fun <reified T> anyForType(): TypeArbitrary<T>
+    where T : Any {
     return Arbitraries.forType(T::class.java)
 }
 

--- a/kotlin/src/main/kotlin/net/jqwik/kotlin/api/SequenceArbitrary.kt
+++ b/kotlin/src/main/kotlin/net/jqwik/kotlin/api/SequenceArbitrary.kt
@@ -15,7 +15,7 @@ import java.util.function.Function
  */
 @API(status = EXPERIMENTAL, since = "1.6.0")
 class SequenceArbitrary<T>(elementArbitrary: Arbitrary<T>) : ArbitraryDecorator<Sequence<T>>(),
-    SizableArbitrary<Sequence<T>> {
+    SizableArbitrary<Sequence<T>> where T: Any {
 
     private var listArbitrary: ListArbitrary<T>
 

--- a/kotlin/src/main/kotlin/net/jqwik/kotlin/internal/KotlinUniqueElementsConfigurator.kt
+++ b/kotlin/src/main/kotlin/net/jqwik/kotlin/internal/KotlinUniqueElementsConfigurator.kt
@@ -39,7 +39,7 @@ class KotlinUniqueElementsConfigurator : ArbitraryConfigurator {
     private fun <T> configureSequenceArbitrary(
         arbitrary: SequenceArbitrary<T>,
         uniqueness: UniqueElements
-    ): SequenceArbitrary<T> {
+    ): SequenceArbitrary<T> where T: Any {
         val extractor = extractor(uniqueness) as Function<T, Any>
         return arbitrary.uniqueElements(extractor)
     }


### PR DESCRIPTION
## Overview

Make jqwik `kotlin` module work with Kotlin 1.9.0

The problems are mostly about arbitrary types. While the Java implementation does not differentiate between nullable and non-nullable types, the Kotlin compiler assumes that they are non-nullable and deferes `T & Any` whereas the Kotlin functions use just `T` since the incoming arbitraries (or functions or whatever) could be nullable or non-nullable.

## Problem

How to handle this type mismatch correctly?

---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jqwik-team/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
