### PR TITLE
Kotlin Combinator DSL

### DIFF
--- a/documentation/src/docs/include/kotlin-module.md
+++ b/documentation/src/docs/include/kotlin-module.md
@@ -446,14 +446,14 @@ combine {
     val second by Arbitraries.strings()
     // ...
 
-    createAs {
+    combineAs {
         "first: $first, second: $second"
     }
 }
 ```
 
 Note that accessing the `first` or `second` properties in the example above 
-_outside_ the `createAs` block would result in an error.
+_outside_ the `combineAs` block would result in an error.
 
 In the background, this is equivalent to:
 
@@ -473,7 +473,7 @@ combine {
     filter { first.isNotEmpty() }
     filter { first != second }
 
-    createAs {
+    combineAs {
         // 'first' will never be empty or equal to 'second'
 
         "first: $first, second: $second"

--- a/documentation/src/docs/include/kotlin-module.md
+++ b/documentation/src/docs/include/kotlin-module.md
@@ -27,6 +27,7 @@ __Table of contents:__
   - [Jqwik Tuples in Kotlin](#jqwik-tuples-in-kotlin)
   - [Type-based Arbitraries](#type-based-arbitraries)
   - [Diverse Convenience Functions](#diverse-convenience-functions)
+  - [Combinator DSL](#combinator-dsl)
 - [Quirks and Bugs](#quirks-and-bugs)
 
 #### Build Configuration for Kotlin
@@ -477,6 +478,20 @@ combine {
         // 'first' will never be empty or equal to 'second'
 
         "first: $first, second: $second"
+    }
+}
+```
+
+And you can also achieve the `flatCombine` behaviour, by using `flatCombineAs`:
+
+```kotlin
+combine {
+    val first by Arbitraries.strings()
+    val second by Arbitraries.strings()
+    // ...
+
+    flatCombineAs {
+        Arbitraries.just("first: $first, second: $second")
     }
 }
 ```

--- a/documentation/src/docs/include/kotlin-module.md
+++ b/documentation/src/docs/include/kotlin-module.md
@@ -463,6 +463,24 @@ combine(listOf(Arbitraries.strings(), Arbitraries.strings())) { values ->
 }
 ```
 
+It is also possible to use filters within the combinator DSL:
+
+```kotlin
+combine {
+    val first by Arbitraries.strings()
+    val second by Arbitraries.strings()
+
+    filter { first.isNotEmpty() }
+    filter { first != second }
+
+    createAs {
+        // 'first' will never be empty or equal to 'second'
+
+        "first: $first, second: $second"
+    }
+}
+```
+
 #### Quirks and Bugs
 
 - Despite our best effort to enrich jqwik's Java API with nullability information,

--- a/documentation/src/docs/include/kotlin-module.md
+++ b/documentation/src/docs/include/kotlin-module.md
@@ -432,6 +432,36 @@ There's a more Kotlinish way to do the same: `anyForType<MyType>()`.
 - `Collection<T>.anySubset()` can replace 
   `Arbitraries.subsetOf(collection: Collection<T>)`
 
+##### Combinator DSL
+
+The combinator DSL provides another, potentially more convenient, wrapper for
+`Combinators.combine`.
+
+Instead of a list of arguments, it uses kotlin's property delegates to refer to
+the arbitraries that are being combined:
+
+```kotlin
+combine {
+    val first by Arbitraries.strings()
+    val second by Arbitraries.strings()
+    // ...
+
+    createAs {
+        "first: $first, second: $second"
+    }
+}
+```
+
+Note that accessing the `first` or `second` properties in the example above 
+_outside_ the `createAs` block would result in an error.
+
+In the background, this is equivalent to:
+
+```kt
+combine(listOf(Arbitraries.strings(), Arbitraries.strings())) { values ->
+    "first: ${values[0]}, second: ${values[1]}"
+}
+```
 
 #### Quirks and Bugs
 

--- a/kotlin/src/main/kotlin/net/jqwik/kotlin/api/CombinatorDsl.kt
+++ b/kotlin/src/main/kotlin/net/jqwik/kotlin/api/CombinatorDsl.kt
@@ -152,7 +152,7 @@ internal class ValueBindings {
 
             block()
         } finally {
-            current.remove()
+            current.set(null)
         }
     }
 }

--- a/kotlin/src/main/kotlin/net/jqwik/kotlin/api/CombinatorDsl.kt
+++ b/kotlin/src/main/kotlin/net/jqwik/kotlin/api/CombinatorDsl.kt
@@ -19,7 +19,7 @@ import kotlin.reflect.KProperty
  *     filter { first.isNotEmpty() }
  *     filter { first != second }
  *
- *     createAs {
+ *     combineAs {
  *         "first: $first, second: $second"
  *     }
  * }
@@ -78,8 +78,8 @@ class CombinatorScope internal constructor(private val bindings: ValueBindings) 
 
 @API(status = API.Status.EXPERIMENTAL, since = "1.8.0")
 sealed class Combined<R>(
-    val arbitraries: List<Arbitrary<*>>,
-    val filters: List<() -> Boolean>
+    private val arbitraries: List<Arbitrary<*>>,
+    private val filters: List<() -> Boolean>
 ) {
     internal fun createArbitrary(bindings: ValueBindings): Arbitrary<R> {
         @Suppress("UNCHECKED_CAST")

--- a/kotlin/src/main/kotlin/net/jqwik/kotlin/api/CombinatorDsl.kt
+++ b/kotlin/src/main/kotlin/net/jqwik/kotlin/api/CombinatorDsl.kt
@@ -49,7 +49,7 @@ class ArbitraryProperty<T> internal constructor(
 
 @API(status = API.Status.EXPERIMENTAL, since = "1.8.0")
 class CombinatorScope internal constructor(private val bindings: ValueBindings) {
-    private var created = AtomicBoolean(false)
+    private val created = AtomicBoolean(false)
     private val arbitraries = mutableListOf<Arbitrary<*>>()
     private val filters = mutableListOf<() -> Boolean>()
 

--- a/kotlin/src/main/kotlin/net/jqwik/kotlin/api/CombinatorDsl.kt
+++ b/kotlin/src/main/kotlin/net/jqwik/kotlin/api/CombinatorDsl.kt
@@ -131,7 +131,14 @@ class Combined<R> internal constructor(
     }
 }
 
+/**
+ * A class that provides the [ArbitraryProperty] instances access to the relevant values when accessed from within the
+ * block passed to [CombinatorScope.createAs].
+ */
 internal class ValueBindings {
+    // Because the ArbitraryProperty instances have to be created once per "combine" call (so once per Arbitrary
+    // instance), they are shared across all invocations of the "createAs" block. To prevent issues with potential
+    // parallel generation of arbitrary values, we use a ThreadLocal here.
     private val current = ThreadLocal<List<*>>()
 
     operator fun <T> get(index: Int): T {

--- a/kotlin/src/main/kotlin/net/jqwik/kotlin/api/CombinatorDsl.kt
+++ b/kotlin/src/main/kotlin/net/jqwik/kotlin/api/CombinatorDsl.kt
@@ -1,0 +1,97 @@
+package net.jqwik.kotlin.api
+
+import net.jqwik.api.Arbitrary
+import org.apiguardian.api.API
+import java.util.Optional
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KProperty
+
+
+/**
+ * Combine arbitraries using the combinator DSL:
+ *
+ * ```kotlin
+ * combine {
+ *     val first by Arbitraries.strings()
+ *     val second by Arbitraries.strings()
+ *
+ *     createAs {
+ *         "first: $first, second: $second"
+ *     }
+ * }
+ * ```
+ *
+ * @return new Arbitrary instance
+ */
+@API(status = API.Status.EXPERIMENTAL, since = "1.8.0")
+fun <R> combine(
+    combinator: CombinatorScope.() -> Combined<R>
+): Arbitrary<R> {
+    val combined = CombinatorScope().combinator()
+
+    @Suppress("UNCHECKED_CAST")
+    return combine(combined.arbitraries as List<Arbitrary<Any?>>) { values ->
+        try {
+            for ((property, value) in combined.properties zip values) {
+                property.bind(value)
+            }
+
+            CombinatorCreateScope().(combined.combinator)()
+        } finally {
+            for (it in combined.properties) {
+                it.unbind()
+            }
+        }
+    }
+}
+
+@API(status = API.Status.EXPERIMENTAL, since = "1.8.0")
+class ArbitraryProperty<T> internal constructor() : ReadOnlyProperty<Nothing?, T> {
+    private val currentValue = ThreadLocal<Optional<T & Any>>()
+
+    internal fun bind(value: Any?) {
+        @Suppress("UNCHECKED_CAST")
+        currentValue.set(Optional.ofNullable(value as T))
+    }
+
+    internal fun unbind() {
+        currentValue.remove()
+    }
+
+    override fun getValue(thisRef: Nothing?, property: KProperty<*>): T {
+        val values = currentValue.get() ?: run {
+            error("Arbitrary delegate must only be used inside 'combineAs'")
+        }
+
+        return values.orElse(null)
+    }
+}
+
+@API(status = API.Status.EXPERIMENTAL, since = "1.8.0")
+class CombinatorScope internal constructor() {
+    private val arbitraries = mutableListOf<Arbitrary<*>>()
+    private val properties = mutableListOf<ArbitraryProperty<*>>()
+
+    operator fun <T> Arbitrary<T>.provideDelegate(thisRef: Nothing?, property: KProperty<*>): ArbitraryProperty<T> {
+        val arbitraryProperty = ArbitraryProperty<T>()
+
+        arbitraries += this
+        properties += arbitraryProperty
+
+        return arbitraryProperty
+    }
+
+    fun <R> createAs(creator: CombinatorCreateScope.() -> R): Combined<R> {
+        return Combined(arbitraries.toList(), properties.toList(), creator)
+    }
+}
+
+@API(status = API.Status.EXPERIMENTAL, since = "1.8.0")
+class CombinatorCreateScope internal constructor()
+
+@API(status = API.Status.EXPERIMENTAL, since = "1.8.0")
+class Combined<R> internal constructor(
+    val arbitraries: List<Arbitrary<*>>,
+    val properties: List<ArbitraryProperty<*>>,
+    val combinator: CombinatorCreateScope.() -> R
+)

--- a/kotlin/src/test/kotlin/net/jqwik/kotlin/CombinatorDslTests.kt
+++ b/kotlin/src/test/kotlin/net/jqwik/kotlin/CombinatorDslTests.kt
@@ -1,18 +1,20 @@
 package net.jqwik.kotlin
 
+import net.jqwik.api.*
 import net.jqwik.api.Arbitraries.just
-import net.jqwik.api.Example
-import net.jqwik.api.ForAll
-import net.jqwik.api.Group
-import net.jqwik.kotlin.api.combine
-import net.jqwik.kotlin.api.orNull
+import net.jqwik.kotlin.api.*
+import net.jqwik.testing.TestingSupport
 import net.jqwik.testing.TestingSupport.assertAtLeastOneGeneratedOf
 import net.jqwik.testing.TestingSupport.checkAllGenerated
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import java.util.*
 
 @Group
 class CombinatorDslTests {
+
+    private val oneToThree: Arbitrary<Int> = Int.any(1..3)
+
     @Example
     fun `combine arbitraries`() {
         val combined = combine {
@@ -20,7 +22,7 @@ class CombinatorDslTests {
             val v2 by just(2)
 
             createAs {
-                v1 + v2
+                v1!! + v2!!
             }
         }
 
@@ -34,7 +36,7 @@ class CombinatorDslTests {
             val v2 by just(2)
 
             createAs {
-                (v1 ?: 0) + v2
+                (v1 ?: 0) + v2!!
             }
         }
 
@@ -46,5 +48,62 @@ class CombinatorDslTests {
 
         assertAtLeastOneGeneratedOf(generator, random, 2)
         assertAtLeastOneGeneratedOf(generator, random, 3)
+    }
+
+    @Example
+    fun `filter arbitraries`(@ForAll random: Random) {
+        val combined = combine {
+            val v1 by oneToThree
+            val v2 by oneToThree
+
+            filter { v1 != v2 }
+
+            createAs {
+                Tuple.of(v1, v2)
+            }
+        }
+
+        TestingSupport.assertAllGenerated(combined.generator(1000), random) { (first, second) ->
+            assertThat(first).isNotEqualTo(second)
+        }
+    }
+
+    @Example
+    fun `throw when calling createAs twice`() {
+        assertThatThrownBy {
+            combine {
+                val value by oneToThree
+
+                createAs { value }
+                createAs { value }
+            }
+        }.isInstanceOf(IllegalStateException::class.java)
+    }
+
+    @Example
+    fun `throw when using value outside createAs`() {
+        assertThatThrownBy {
+            combine {
+                val value by oneToThree
+
+                val usage = value
+
+                createAs { usage }
+            }
+        }.isInstanceOf(IllegalStateException::class.java)
+    }
+
+    @Example
+    fun `flatCombine arbitraries`() {
+        val combined = flatCombine {
+            val v1 by just(1)
+            val v2 by just(2)
+
+            createAs {
+                just(v1!! + v2!!)
+            }
+        }
+
+        assertThat(combined.sample()).isEqualTo(3)
     }
 }

--- a/kotlin/src/test/kotlin/net/jqwik/kotlin/CombinatorDslTests.kt
+++ b/kotlin/src/test/kotlin/net/jqwik/kotlin/CombinatorDslTests.kt
@@ -3,6 +3,7 @@ package net.jqwik.kotlin
 import net.jqwik.api.*
 import net.jqwik.api.Arbitraries.just
 import net.jqwik.kotlin.api.*
+import net.jqwik.testing.ShrinkingSupport
 import net.jqwik.testing.TestingSupport
 import net.jqwik.testing.TestingSupport.assertAtLeastOneGeneratedOf
 import net.jqwik.testing.TestingSupport.checkAllGenerated
@@ -105,5 +106,18 @@ class CombinatorDslTests {
         }
 
         assertThat(combined.sample()).isEqualTo(3)
+    }
+
+    @Property
+    fun `shrink combined arbitrary`(@ForAll random: Random) {
+        val combined = combine {
+            val i by Arbitraries.integers()
+            val s by Arbitraries.strings().alpha().ofMinLength(1)
+
+            combineAs { i.toString() + s }
+        }
+
+        val shrunkValue = ShrinkingSupport.falsifyThenShrink(combined, random)
+        assertThat(shrunkValue).isIn("0A", "0a")
     }
 }

--- a/kotlin/src/test/kotlin/net/jqwik/kotlin/CombinatorDslTests.kt
+++ b/kotlin/src/test/kotlin/net/jqwik/kotlin/CombinatorDslTests.kt
@@ -70,7 +70,7 @@ class CombinatorDslTests {
     }
 
     @Example
-    fun `throw when calling createAs twice`() {
+    fun `throw when calling combineAs twice`() {
         assertThatThrownBy {
             combine {
                 val value by oneToThree
@@ -82,7 +82,7 @@ class CombinatorDslTests {
     }
 
     @Example
-    fun `throw when using value outside createAs`() {
+    fun `throw when using value outside combineAs`() {
         assertThatThrownBy {
             combine {
                 val value by oneToThree

--- a/kotlin/src/test/kotlin/net/jqwik/kotlin/CombinatorDslTests.kt
+++ b/kotlin/src/test/kotlin/net/jqwik/kotlin/CombinatorDslTests.kt
@@ -1,0 +1,50 @@
+package net.jqwik.kotlin
+
+import net.jqwik.api.Arbitraries.just
+import net.jqwik.api.Example
+import net.jqwik.api.ForAll
+import net.jqwik.api.Group
+import net.jqwik.kotlin.api.combine
+import net.jqwik.kotlin.api.orNull
+import net.jqwik.testing.TestingSupport.assertAtLeastOneGeneratedOf
+import net.jqwik.testing.TestingSupport.checkAllGenerated
+import org.assertj.core.api.Assertions.assertThat
+import java.util.*
+
+@Group
+class CombinatorDslTests {
+    @Example
+    fun `combine arbitraries`() {
+        val combined = combine {
+            val v1 by just(1)
+            val v2 by just(2)
+
+            createAs {
+                v1 + v2
+            }
+        }
+
+        assertThat(combined.sample()).isEqualTo(3)
+    }
+
+    @Example
+    fun `combine nullable arbitraries`(@ForAll random: Random) {
+        val combined = combine {
+            val v1 by just(1).orNull(0.5)
+            val v2 by just(2)
+
+            createAs {
+                (v1 ?: 0) + v2
+            }
+        }
+
+        val generator = combined.generator(1000)
+        checkAllGenerated(
+            generator,
+            random
+        ) { value -> value == 2 || value == 3 }
+
+        assertAtLeastOneGeneratedOf(generator, random, 2)
+        assertAtLeastOneGeneratedOf(generator, random, 3)
+    }
+}

--- a/kotlin/src/test/kotlin/net/jqwik/kotlin/CombinatorDslTests.kt
+++ b/kotlin/src/test/kotlin/net/jqwik/kotlin/CombinatorDslTests.kt
@@ -21,7 +21,7 @@ class CombinatorDslTests {
             val v1 by just(1)
             val v2 by just(2)
 
-            createAs {
+            combineAs {
                 v1!! + v2!!
             }
         }
@@ -35,7 +35,7 @@ class CombinatorDslTests {
             val v1 by just(1).orNull(0.5)
             val v2 by just(2)
 
-            createAs {
+            combineAs {
                 (v1 ?: 0) + v2!!
             }
         }
@@ -58,7 +58,7 @@ class CombinatorDslTests {
 
             filter { v1 != v2 }
 
-            createAs {
+            combineAs {
                 Tuple.of(v1, v2)
             }
         }
@@ -74,8 +74,8 @@ class CombinatorDslTests {
             combine {
                 val value by oneToThree
 
-                createAs { value }
-                createAs { value }
+                combineAs { value }
+                combineAs { value }
             }
         }.isInstanceOf(IllegalStateException::class.java)
     }
@@ -88,18 +88,18 @@ class CombinatorDslTests {
 
                 val usage = value
 
-                createAs { usage }
+                combineAs { usage }
             }
         }.isInstanceOf(IllegalStateException::class.java)
     }
 
     @Example
     fun `flatCombine arbitraries`() {
-        val combined = flatCombine {
+        val combined = combine {
             val v1 by just(1)
             val v2 by just(2)
 
-            createAs {
+            flatCombineAs {
                 just(v1!! + v2!!)
             }
         }

--- a/kotlin/src/test/kotlin/net/jqwik/kotlin/CombinatorDslTests.kt
+++ b/kotlin/src/test/kotlin/net/jqwik/kotlin/CombinatorDslTests.kt
@@ -11,7 +11,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import java.util.*
 
-@Group
+@PropertyDefaults(tries = 100, shrinking = ShrinkingMode.FULL)
 class CombinatorDslTests {
 
     private val oneToThree: Arbitrary<Int> = Int.any(1..3)


### PR DESCRIPTION
## Overview

Currently, we have a lot of combinators in our kotlin code. They generally look like this:

```kt
fun current(): Arbitrary<String> {
    return combine(
        String.any(),
        String.any(),
        String.any(),
        String.any(),
        String.any(),
        String.any(),
        String.any(),
    ) { first, second, third, fourth, fifth, sixth, seventh ->
        "1: $first, 2: $second, 3: $third, 4: $fourth, 5: $fifth, 6: $sixth, 7: $seventh"
    }
}
```

This has two major disadvantages in my opinion:
- It is hard to read and modify, because you don't directly know which arbitrary belongs to which value
- This only works with up to eight Arbitraries, because of the way the combinator functions have to be written

The syntax that is added by this PR allows to write a combinator like this:

```kt
fun proposed(): Arbitrary<String> {
    return combine {
        val first by String.any()
        val second by String.any()
        val third by String.any()
        val fourth by String.any()
        val fifth by String.any()
        val sixth by String.any()
        val seventh by String.any()

        createAs {
            "1: $first, 2: $second, 3: $third, 4: $fourth, 5: $fifth, 6: $sixth, 7: $seventh"
        }
    }
}
```

### Details

I just wanted to create a PR in case you like this DSL, because I think it would be a cool addition. The actual implementation is somewhat hacky, so I can imagine that it might not be something you want. Otherwise I'll just keep it in our fork we use internally 😉

---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jqwik-team/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
