### PR TITLE
Typo in javadoc for ChangeDetector

### DIFF
--- a/api/src/main/java/net/jqwik/api/state/Action.java
+++ b/api/src/main/java/net/jqwik/api/state/Action.java
@@ -89,7 +89,7 @@ public interface Action<S extends @Nullable Object> {
 		 * Return an arbitrary for transformers that depends on the previous state.
 		 *
 		 * <p>
-		 * In addition to performing a state transformation the transformin function
+		 * In addition to performing a state transformation the transforming function
 		 * can also check or assert post-conditions and invariants that should hold when doing the transformation.
 		 * </p>
 		 *

--- a/api/src/main/java/net/jqwik/api/state/ChangeDetector.java
+++ b/api/src/main/java/net/jqwik/api/state/ChangeDetector.java
@@ -10,7 +10,7 @@ import static org.apiguardian.api.API.Status.*;
 
 /**
  * A change detector is used to determine if a stateful object has changed after the application of a transformer.
- * This can become improve shrinking of {@linkplain Chain chins} and {@linkplain ActionChain actionChains}.
+ * This can become improve shrinking of {@linkplain Chain chains} and {@linkplain ActionChain actionChains}.
  *
  * @param <T> the type of the stateful object
  *


### PR DESCRIPTION
## Overview

This is a small typo in the javadoc for ChangeDetector


---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jqwik-team/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
