### PR TITLE
Make `description` method public in `JustTransform`

### DIFF
--- a/api/src/main/java/net/jqwik/api/state/Action.java
+++ b/api/src/main/java/net/jqwik/api/state/Action.java
@@ -89,7 +89,7 @@ public interface Action<S extends @Nullable Object> {
 		 * Return an arbitrary for transformers that depends on the previous state.
 		 *
 		 * <p>
-		 * In addition to performing a state transformation the transformin function
+		 * In addition to performing a state transformation the transforming function
 		 * can also check or assert post-conditions and invariants that should hold when doing the transformation.
 		 * </p>
 		 *

--- a/api/src/main/java/net/jqwik/api/state/Action.java
+++ b/api/src/main/java/net/jqwik/api/state/Action.java
@@ -150,7 +150,7 @@ public interface Action<S extends @Nullable Object> {
 
 		public abstract S transform(S state);
 
-		String description() {
+		public String description() {
 			return getClass().getSimpleName();
 		}
 	}

--- a/api/src/main/java/net/jqwik/api/state/ChangeDetector.java
+++ b/api/src/main/java/net/jqwik/api/state/ChangeDetector.java
@@ -10,7 +10,7 @@ import static org.apiguardian.api.API.Status.*;
 
 /**
  * A change detector is used to determine if a stateful object has changed after the application of a transformer.
- * This can become improve shrinking of {@linkplain Chain chins} and {@linkplain ActionChain actionChains}.
+ * This can become improve shrinking of {@linkplain Chain chains} and {@linkplain ActionChain actionChains}.
  *
  * @param <T> the type of the stateful object
  *


### PR DESCRIPTION
## Overview

Make `description` method public in `JustTransform` - this will allow the extender of `JustTransform` to use custom descriptions.

### Details
For example, with `JustMutate`, it is possible to override the description:
```java
class RemoveAction extends JustMutate<List<Integer>> {
    
    String description = "RemoveAction";

    @Override
    public void mutate(List<Integer> state) {
        description = "Mutating by removing something";
    }

    @Override
    public boolean precondition(List<Integer> state) {
        return true;
    }

    @Override
    public String description() {
        return description; // returns the latest description
    }
}
```

But it is not possible to do this with `JustTransform`:
```java
class AddAction extends JustTransform<List<Integer>> {

    String description = "RemoveAction";

    @Override
    public List<Integer> transform(List<Integer> state) {
        description = "Mutating by adding something";
        return state;
    }

    @Override
    public boolean precondition(List<Integer> state) {
        return true;
    }

    /*
    // this is not possible:
    @Override
    public String description() {
        return description; // returns the latest description
    }
    */
}
```
---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jqwik-team/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
