### PR TITLE
fix: use try-with-resources for ObjectOutputStream to ensure all the data is written

### DIFF
--- a/api/src/main/java/net/jqwik/api/support/LambdaSupport.java
+++ b/api/src/main/java/net/jqwik/api/support/LambdaSupport.java
@@ -92,8 +92,9 @@ public class LambdaSupport {
 
 	private static <T> byte[] serialize(T l1) throws IOException {
 		ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-		ObjectOutputStream outputStream = new ObjectOutputStream(byteArrayOutputStream);
-		outputStream.writeObject(l1);
+		try (ObjectOutputStream outputStream = new ObjectOutputStream(byteArrayOutputStream);) {
+			outputStream.writeObject(l1);
+		}
 		return byteArrayOutputStream.toByteArray();
 	}
 

--- a/engine/src/test/java/net/jqwik/engine/execution/GenerationInfoTests.java
+++ b/engine/src/test/java/net/jqwik/engine/execution/GenerationInfoTests.java
@@ -162,7 +162,9 @@ class GenerationInfoTests {
 		void serializeWithEmptyShrinkingSequence() throws Exception {
 			GenerationInfo generationInfo = new GenerationInfo("4242", 41);
 
-			outputStream().writeObject(generationInfo);
+			try (ObjectOutputStream os = outputStream();) {
+				os.writeObject(generationInfo);
+			}
 
 			// System.out.println("### size: " + byteArrayOutputStream.toByteArray().length);
 
@@ -175,7 +177,9 @@ class GenerationInfoTests {
 			GenerationInfo generationInfo = new GenerationInfo("4242", 41)
 				.appendShrinkingSequence(sequence);
 
-			outputStream().writeObject(generationInfo);
+			try (ObjectOutputStream os = outputStream();) {
+				os.writeObject(generationInfo);
+			}
 
 			// System.out.println("### size: " + byteArrayOutputStream.toByteArray().length);
 
@@ -190,7 +194,9 @@ class GenerationInfoTests {
 				generationInfo = generationInfo.appendShrinkingSequence(sequence);
 			}
 
-			outputStream().writeObject(generationInfo);
+			try (ObjectOutputStream os = outputStream();) {
+				os.writeObject(generationInfo);
+			}
 
 			// System.out.println("### size: " + byteArrayOutputStream.toByteArray().length);
 
@@ -203,7 +209,9 @@ class GenerationInfoTests {
 			GenerationInfo generationInfo = new GenerationInfo("4242", 41)
 				.appendShrinkingSequence(sequence);
 
-			outputStream().writeObject(generationInfo);
+			try (ObjectOutputStream os = outputStream();) {
+				os.writeObject(generationInfo);
+			}
 
 			// System.out.printf("### size: %s (%s)%n", sequence.size(), byteArrayOutputStream.toByteArray().length);
 


### PR DESCRIPTION
Previously, ObjectOutputStream could silently buffer data in the internal buffers

---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jqwik-team/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
